### PR TITLE
Add English README links and adjust active language tabs

### DIFF
--- a/locale/README_AR.md
+++ b/locale/README_AR.md
@@ -5,12 +5,12 @@
 
 <div align="center">
   <a href="README_UA.md">🇺🇦 Українська</a> &nbsp;|&nbsp;
+  <a href="../README.md">🇬🇧 English</a> &nbsp;|&nbsp;
   <a href="README_ES.md">🇪🇸 Español</a> &nbsp;|&nbsp;
   <a href="README_FR.md">🇫🇷 Français</a> &nbsp;|&nbsp;
   <a href="README_DE.md">🇩🇪 Deutsch</a> &nbsp;|&nbsp;
   <a href="README_ZH.md">🇨🇳 中文</a> &nbsp;|&nbsp;
   <a href="README_HI.md">🇮🇳 हिन्दी</a> &nbsp;|&nbsp;
-  <a href="README_AR.md">🇸🇦 العربية</a> &nbsp;|&nbsp;
   <a href="README_PT.md">🇵🇹 Português</a> &nbsp;|&nbsp;
   <a href="README_BN.md">🇧🇩 বাংলা</a> &nbsp;|&nbsp;
   <a href="README_UR.md">🇵🇰 اردو</a> &nbsp;|&nbsp;

--- a/locale/README_BN.md
+++ b/locale/README_BN.md
@@ -5,6 +5,7 @@
 
 <div align="center">
   <a href="README_UA.md">🇺🇦 Українська</a> &nbsp;|&nbsp;
+  <a href="../README.md">🇬🇧 English</a> &nbsp;|&nbsp;
   <a href="README_ES.md">🇪🇸 Español</a> &nbsp;|&nbsp;
   <a href="README_FR.md">🇫🇷 Français</a> &nbsp;|&nbsp;
   <a href="README_DE.md">🇩🇪 Deutsch</a> &nbsp;|&nbsp;
@@ -12,7 +13,6 @@
   <a href="README_HI.md">🇮🇳 हिन्दी</a> &nbsp;|&nbsp;
   <a href="README_AR.md">🇸🇦 العربية</a> &nbsp;|&nbsp;
   <a href="README_PT.md">🇵🇹 Português</a> &nbsp;|&nbsp;
-  <a href="README_BN.md">🇧🇩 বাংলা</a> &nbsp;|&nbsp;
   <a href="README_UR.md">🇵🇰 اردو</a> &nbsp;|&nbsp;
   <a href="README_JP.md">🇯🇵 日本語</a> &nbsp;|&nbsp;
   <a href="README_KO.md">🇰🇷 한국어</a>

--- a/locale/README_HI.md
+++ b/locale/README_HI.md
@@ -10,7 +10,6 @@
   <a href="README_FR.md">🇫🇷 Français</a> &nbsp;|&nbsp;
   <a href="README_DE.md">🇩🇪 Deutsch</a> &nbsp;|&nbsp;
   <a href="README_ZH.md">🇨🇳 中文</a> &nbsp;|&nbsp;
-  <a href="README_HI.md">🇮🇳 हिन्दी</a> &nbsp;|&nbsp;
   <a href="README_AR.md">🇸🇦 العربية</a> &nbsp;|&nbsp;
   <a href="README_PT.md">🇵🇹 Português</a> &nbsp;|&nbsp;
   <a href="README_BN.md">🇧🇩 বাংলা</a> &nbsp;|&nbsp;

--- a/locale/README_JP.md
+++ b/locale/README_JP.md
@@ -5,6 +5,7 @@
 
 <div align="center">
   <a href="README_UA.md">🇺🇦 Українська</a> &nbsp;|&nbsp;
+  <a href="../README.md">🇬🇧 English</a> &nbsp;|&nbsp;
   <a href="README_ES.md">🇪🇸 Español</a> &nbsp;|&nbsp;
   <a href="README_FR.md">🇫🇷 Français</a> &nbsp;|&nbsp;
   <a href="README_DE.md">🇩🇪 Deutsch</a> &nbsp;|&nbsp;
@@ -14,7 +15,6 @@
   <a href="README_PT.md">🇵🇹 Português</a> &nbsp;|&nbsp;
   <a href="README_BN.md">🇧🇩 বাংলা</a> &nbsp;|&nbsp;
   <a href="README_UR.md">🇵🇰 اردو</a> &nbsp;|&nbsp;
-  <a href="README_JP.md">🇯🇵 日本語</a> &nbsp;|&nbsp;
   <a href="README_KO.md">🇰🇷 한국어</a>
 </div>
 

--- a/locale/README_KO.md
+++ b/locale/README_KO.md
@@ -5,6 +5,7 @@
 
 <div align="center">
   <a href="README_UA.md">🇺🇦 Українська</a> &nbsp;|&nbsp;
+  <a href="../README.md">🇬🇧 English</a> &nbsp;|&nbsp;
   <a href="README_ES.md">🇪🇸 Español</a> &nbsp;|&nbsp;
   <a href="README_FR.md">🇫🇷 Français</a> &nbsp;|&nbsp;
   <a href="README_DE.md">🇩🇪 Deutsch</a> &nbsp;|&nbsp;

--- a/locale/README_UR.md
+++ b/locale/README_UR.md
@@ -5,6 +5,7 @@
 
 <div align="center">
   <a href="locale/README_UA.md">🇺🇦 Українська</a> &nbsp;|&nbsp;
+  <a href="../README.md">🇬🇧 English</a> &nbsp;|&nbsp;
   <a href="locale/README_ES.md">🇪🇸 Español</a> &nbsp;|&nbsp;
   <a href="locale/README_FR.md">🇫🇷 Français</a> &nbsp;|&nbsp;
   <a href="locale/README_DE.md">🇩🇪 Deutsch</a> &nbsp;|&nbsp;


### PR DESCRIPTION
Introduced links to the English README across multiple localized README files for better navigation. Also removed the self-referential active language tabs for cleaner presentation.